### PR TITLE
Add optional separator argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ keywords = ["graph"]
 license = "MIT"
 
 [dependencies]
-rand="0.4"
-memmap="0.5.2"
+rand="0.7"
+memmap="0.7"

--- a/src/typed_map.rs
+++ b/src/typed_map.rs
@@ -18,7 +18,7 @@ impl<T:Copy> TypedMemoryMap<T> {
         let size = file.metadata().ok().expect("error reading metadata").len() as usize;
 
         TypedMemoryMap {
-            map: memmap::Mmap::open(&file, memmap::Protection::Read).unwrap(),
+            map: unsafe { memmap::Mmap::map(&file).unwrap() },
             len: size / mem::size_of::<T>(),
             phn: PhantomData,
         }
@@ -29,6 +29,6 @@ impl<T:Copy> ops::Index<ops::RangeFull> for TypedMemoryMap<T> {
     type Output = [T];
     #[inline]
     fn index(&self, _index: ops::RangeFull) -> &[T] {
-        unsafe { slice::from_raw_parts(self.map.ptr() as *const T, self.len) }
+        unsafe { slice::from_raw_parts(self.map.as_ptr() as *const T, self.len) }
     }
 }


### PR DESCRIPTION
I made the following updates:
* An optional separator char can be specified, when the input file is comma separated for example.
* Remove dedup by default.
* Added useful output messages.
* Updated the library dependencies.